### PR TITLE
Register bundle view paths with bundle as namespace

### DIFF
--- a/src/DependencyInjection/HandlebarsExtension.php
+++ b/src/DependencyInjection/HandlebarsExtension.php
@@ -98,6 +98,10 @@ class HandlebarsExtension extends Extension
             $dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views';
             if (is_dir($dir)) {
                 $handlebarsFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
+                $handlebarsFilesystemLoaderDefinition->addMethodCall('addPath', array(
+                    $dir,
+                    $this->normalizeBundleNameForLoaderNamespace($bundle)
+                ));
             }
             $container->addResource(new FileExistenceResource($dir));
 
@@ -105,9 +109,22 @@ class HandlebarsExtension extends Extension
             $dir = dirname($reflection->getFileName()).'/Resources/views';
             if (is_dir($dir)) {
                 $handlebarsFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
+                $handlebarsFilesystemLoaderDefinition->addMethodCall('addPath', array(
+                    $dir,
+                    $this->normalizeBundleNameForLoaderNamespace($bundle)
+                ));
             }
             $container->addResource(new FileExistenceResource($dir));
         }
+    }
+
+    private function normalizeBundleNameForLoaderNamespace($bundle)
+    {
+        if ('Bundle' === substr($bundle, -6)) {
+            $bundle = substr($bundle, 0, -6);
+        }
+
+        return $bundle;
     }
 
     private function addConfigPath($config, ContainerBuilder $container)

--- a/src/Tests/DependencyInjection/HandlebarsExtensionTest.php
+++ b/src/Tests/DependencyInjection/HandlebarsExtensionTest.php
@@ -123,7 +123,7 @@ class HandlebarsExtensionTest extends \PHPUnit_Framework_TestCase
         $extension->load([['assetic' => true]], $container->reveal());
     }
 
-    public function testBundlePathes()
+    public function testBundlePaths()
     {
         $bundleDir = realpath(__DIR__ . '/../..');
         $kernelDir = $bundleDir . '/Tests/Fixtures';
@@ -135,6 +135,8 @@ class HandlebarsExtensionTest extends \PHPUnit_Framework_TestCase
         $loaderDefinition->addMethodCall("addPath", [$resourceDir])->shouldBeCalled();
         $loaderDefinition->addMethodCall("addPath", [$kernelDir . '/Resources/TestBundle/views'])->shouldBeCalled();
         $loaderDefinition->addMethodCall("addPath", [$kernelDir . '/TestBundle/Resources/views'])->shouldBeCalled();
+        $loaderDefinition->addMethodCall("addPath", [$kernelDir . '/Resources/TestBundle/views', 'Test'])->shouldBeCalled();
+        $loaderDefinition->addMethodCall("addPath", [$kernelDir . '/TestBundle/Resources/views', 'Test'])->shouldBeCalled();
 
         $container->getParameterBag()->willReturn($parameterBag->reveal());
         $container->hasExtension(Argument::any())->willReturn(false);


### PR DESCRIPTION
The change allows the following syntax to work
```handlebars
{{> @Acme/partials/show-something }}
```

Given a bundle directory structure like this
```
AcmeBundle/
    Resources/
        views/
            partials/
                show-something.hbs
```

This is how the `TwigBundle` handles it, see https://github.com/symfony/twig-bundle/blob/master/DependencyInjection/TwigExtension.php#L83

I've left the non-namespaced path registration in order to avoid backwards incompatibility, it may be desirable to remove this to avoid cross bundle naming clashes.